### PR TITLE
Admin Login Fixes

### DIFF
--- a/DVSAdmin/Views/Login/MFAConfirmation.cshtml
+++ b/DVSAdmin/Views/Login/MFAConfirmation.cshtml
@@ -20,19 +20,23 @@
                     <h1 class="govuk-heading-xl govuk-!-margin-top-8">Multi-factor authentication required</h1>
 
                     <p class="govuk-body">Please confirm the six-digit passcode from your authenticator app, to access your account.</p>
-                    @Html.ValidationMessageFor(m => m.MFACode, "", new { @class = "govuk-error-message" })
-                    <div class="govuk-form-group @(Html.ViewData.ModelState.ContainsKey("MFACode") && Html.ViewData.ModelState["MFACode"].Errors.Count > 0 ? "govuk-form-group--error" :"" )">
-                        <h1 class="govuk-label-wrapper">
-                            <label class="govuk-label govuk-label--s" for="mfacode">
-                                Enter the one time multi factor authentication code
-                            </label>
-                        </h1>
-                        <div id="mfa-code-hint" class="govuk-hint">
-                            This is a six-digit passcode. For example, 623452
-                        </div>
-                        @Html.TextBoxFor(m => m.MFACode, new { @class = "govuk-input govuk-input--width-10", id = "mfacode", name = "mfa-code" })
-                       
-                    </div>
+
+                    @{
+                        var mfaViewModel = new TextBoxViewModel
+                        {
+                            PropertyName = "MFACode",
+                            Label = "Enter the one time multi factor authentication code",
+                            Value = Model?.MFACode,
+                            Hint = "This is a six-digit passcode. For example, 623452",
+                            Class = "govuk-input govuk-input--width-10",
+                            HasError = Html.ViewData.ModelState.ContainsKey("MFACode") && Html.ViewData.ModelState["MFACode"].Errors.Count > 0,
+                            ErrorMessage = Html.ViewData.ModelState.ContainsKey("MFACode") && Html.ViewData.ModelState["MFACode"].Errors.Count > 0 ?
+                        Html.ViewData.ModelState["MFACode"].Errors[0].ErrorMessage : string.Empty,
+                        };
+                    }
+
+                    @await Html.PartialAsync("~/Views/PartialViews/_TextBoxView.cshtml", mfaViewModel)
+
                     <button type="submit" class="govuk-button govuk-!-margin-top-2" data-module="govuk-button">
                         Confirm
                     </button>

--- a/DVSAdmin/Views/PartialViews/_TextBoxView.cshtml
+++ b/DVSAdmin/Views/PartialViews/_TextBoxView.cshtml
@@ -1,24 +1,50 @@
 ﻿@model TextBoxViewModel
 
+@{
+    string hintId = @Model.PropertyName.ToLower() + "-hint";
+    string errorId = @Model.PropertyName.ToLower() + "-error";
+}
+
 <div class="govuk-form-group @(Model.HasError ? "govuk-form-group--error" : "")">
     <label class="govuk-label govuk-label--s" for="@Model.PropertyName.ToLower()">
         @Model.Label
     </label>
-    @if (Model.HasError)
+
+    @if (!string.IsNullOrEmpty(Model.Hint))
     {
-    <p id="@(Model.PropertyName.ToLower())-error" class="govuk-error-message">
-        <span class="govuk-visually-hidden">Error:</span> @Model.ErrorMessage
-    </p>
+        <div id="@hintId" class="govuk-hint">
+            @Model.Hint
+        </div>
+
+        @if (Model.HasError)
+        {
+            <p id="@errorId" class="govuk-error-message">
+                <span class="govuk-visually-hidden">Error:</span> @Model.ErrorMessage
+            </p>
+        }
+
+        @Html.TextBox(Model.PropertyName, Model.Value,
+        new
+        {
+            @id = Model.PropertyName.ToLower(),
+            @class = Model.HasError ? Model.Class + " govuk-input--error" : Model.Class,
+            @aria_describedby = Model.HasError ? hintId + " " + errorId : hintId
+        })
     }
-
-
-    @if (string.IsNullOrEmpty(Model.Hint))
+    else
     {
-    <div id="event-name-hint" class="govuk-hint">
-        @Model.Hint
-    </div>
+        @if (Model.HasError)
+        {
+            <p id="@errorId" class="govuk-error-message">
+                <span class="govuk-visually-hidden">Error:</span> @Model.ErrorMessage
+            </p>
+        }
+        @Html.TextBox(Model.PropertyName, Model.Value,
+        new
+        {
+            @id = Model.PropertyName.ToLower(),
+            @class = Model.HasError ? Model.Class + " govuk-input--error" : Model.Class
+        })
     }
-
-    @Html.TextBox(Model.PropertyName, Model.Value, new { @id = Model.PropertyName.ToLower(), @class = Model.HasError ? Model.Class + " govuk-input--error" : Model.Class })
 
 </div>


### PR DESCRIPTION
- /mfa-confirmation-login - validation error message incorrectly place - fix by replacing textbox with textbox partial
- Textbox partial doesn’t display hint because condition is reversed - needs to be **not** null or empty.
- Textbox partial missing correct contextual hint ID and no aria-describedby on text box for both hint and error
- Position of hint is below error but should be above